### PR TITLE
fix(security): upgrade qs override to 6.14.2 (CVE-2026-2391)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21256,9 +21256,9 @@
       "peer": true
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@octokit/request-error": "^6.1.5",
     "form-data": "^4.0.1",
     "tough-cookie": "^5.0.0",
-    "qs": "6.14.1",
+    "qs": "6.14.2",
     "diff": "^8.0.3",
     "tar": "^7.5.11",
     "fast-xml-parser": "^5.3.8",


### PR DESCRIPTION
## Summary

- Upgrades the `qs` npm override from 6.14.1 to 6.14.2 to address CVE-2026-2391 (CVSS 7.5)
- The vulnerability allows DoS via memory exhaustion when `arrayLimit` is bypassed through comma-separated values
- Tracked in MDKSEC-40

## Test plan

- [x] `npm ls qs` confirms all instances resolve to 6.14.2
- [x] `npm audit` shows no qs findings
- [x] All 99 tests pass
- [ ] BlackDuck rescan confirms clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)