### PR TITLE
fix: add dotenv loading and ingest scripts for GitHub token authentic…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     ".claude-plugin/",
     ".mcp.json",
     "manifest.json",
-    ".npmrc"
+    ".npmrc",
+    ".env.example"
   ],
   "scripts": {
     "audit:signatures": "npm audit signatures",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "config/",
     ".claude-plugin/",
     ".mcp.json",
-    "manifest.json"
+    "manifest.json",
+    ".npmrc"
   ],
   "scripts": {
     "audit:signatures": "npm audit signatures",
@@ -38,7 +39,9 @@
     "fix:all": "npm run lint:fix && npm run format",
     "start": "npx -y supergateway --port 9881 --stdio \"node ./build/start.js\"",
     "ingest": "npm run build && node build/ingest-github-knowledge.js",
-    "ingest:fresh": "npm run build && node build/ingest-github-knowledge.js --no-cache"
+    "ingest:fresh": "npm run build && node build/ingest-github-knowledge.js --no-cache",
+    "ingest:no-build": "node build/ingest-github-knowledge.js",
+    "ingest:no-build:fresh": "node build/ingest-github-knowledge.js --no-cache"
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",

--- a/src/ingest-github-knowledge.ts
+++ b/src/ingest-github-knowledge.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// Load .env file to access GITHUB_TOKEN for authenticated API requests (5000/hour vs 60/hour)
+import { config } from "dotenv";
+config();
+
 import { fetchGitHubKnowledge } from "./github-fetcher.js";
 import { chunkText } from "./chunker.js";
 import { VectorDatabase } from "./vector.js";


### PR DESCRIPTION
…ation

Added dotenv configuration to ingest-github-knowledge.ts to load GITHUB_TOKEN from .env file, enabling authenticated GitHub API requests (5000/hour vs 60/hour unauthenticated limit).

Also added convenience scripts:
- npm run ingest:no-build - run ingest without rebuilding (uses cache)
- npm run ingest:no-build:fresh - run ingest without rebuilding (no cache)

This fixes rate limiting issues when fetching fresh GitHub content.