### PR TITLE
Improve cross-platform compatibility and build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Some of SAP’s larger and complex mobile apps are built using MDK. An example i
 
 ## Setup
 
+### Platform Support
+
+The MDK MCP server supports the following platforms:
+
+- **macOS**: Apple Silicon (ARM64) only
+  - ⚠️ **Note**: Intel Mac (x64) is **not supported** in v0.4.0+ due to onnxruntime-node ≥1.24 dropping darwin/x64 binaries
+- **Linux**: x64, ARM64, and other architectures
+- **Windows**: x64, ARM64
+
+If you're on an Intel Mac, you may need to:
+- Use Rosetta 2 to run the ARM64 version (performance may vary)
+- Or stay on an earlier version that uses onnxruntime-node <1.24
+
 ### Installation Steps
 
 1. Install [node.js 24.11.1](https://nodejs.org/dist/v24.11.1/).

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "audit:signatures": "npm audit signatures",
     "build": "npm run audit:signatures && tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\" && node -e \"require('fs').cpSync('src/lib', 'build/lib', {recursive: true})\" && node -e \"require('fs').cpSync('src/start.js', 'build/start.js')\"",
     "build:no-audit": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\" && node -e \"require('fs').cpSync('src/lib', 'build/lib', {recursive: true})\" && node -e \"require('fs').cpSync('src/start.js', 'build/start.js')\"",
-    "postinstall": "node scripts/cleanup-onnx-binaries.js",
+    "postinstall": "node scripts/cleanup-onnx-binaries.js && node scripts/cleanup-locutus.js && node scripts/install-sharp-platforms.js",
     "test": "node --test --test-concurrency=1 src/tests/*.test.js",
     "lint": "eslint \"src/**/*.ts\" --ignore-pattern \"src/**/*.d.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --ignore-pattern \"src/**/*.d.ts\" --fix",

--- a/scripts/cleanup-locutus.js
+++ b/scripts/cleanup-locutus.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/**
+ * Post-install script to remove locutus/golang directory
+ * This prevents case-collision issues when packaging on case-sensitive filesystems
+ * and extracting on case-insensitive filesystems (macOS/Windows).
+ *
+ * The locutus package (via yo → yeoman-doctor → twig) contains both:
+ * - golang/strings/Index.js
+ * - golang/strings/index.js
+ *
+ * These collide on case-insensitive filesystems and cause "Extension archive contains
+ * colliding entries" errors in Claude Desktop and other zip-based installations.
+ *
+ * Only locutus/php/* is used at runtime by twig, so removing golang/ is safe.
+ *
+ * Run with: node scripts/cleanup-locutus.js
+ * Or automatically via npm postinstall hook
+ */
+
+import { existsSync, rmSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+console.log('\n🔍 Checking for locutus case-collision issue...');
+
+// Path to locutus package
+const locutusPath = join(__dirname, '..', 'node_modules', 'locutus');
+const locutusGolangPath = join(locutusPath, 'golang');
+
+if (!existsSync(locutusPath)) {
+  console.log('ℹ️  locutus package not found, skipping cleanup');
+  process.exit(0);
+}
+
+if (!existsSync(locutusGolangPath)) {
+  console.log('✅ locutus/golang already removed or not present');
+  process.exit(0);
+}
+
+// Calculate size before cleanup
+function getDirectorySize(dirPath) {
+  try {
+    return statSync(dirPath).size;
+  } catch (error) {
+    return 0;
+  }
+}
+
+const sizeBefore = getDirectorySize(locutusGolangPath);
+
+try {
+  rmSync(locutusGolangPath, { recursive: true, force: true });
+  console.log(`🗑️  Removed locutus/golang directory (${(sizeBefore / 1024).toFixed(1)}KB)`);
+  console.log('   This prevents case-collision issues on macOS/Windows filesystems');
+  console.log('   Only locutus/php/* is used at runtime by twig\n');
+} catch (error) {
+  console.warn(`⚠️  Failed to remove locutus/golang:`, error.message);
+  console.warn('   This may cause case-collision issues when packaging\n');
+  process.exit(1);
+}

--- a/scripts/cleanup-onnx-binaries.js
+++ b/scripts/cleanup-onnx-binaries.js
@@ -4,8 +4,20 @@
  * Post-install script to remove unused platform-specific ONNX binaries
  * This can save ~120-140MB by removing binaries for platforms you're not using
  *
+ * IMPORTANT: This cleanup is SKIPPED during CI/packaging to ensure redistributable
+ * bundles contain binaries for ALL platforms. Without all binaries, the server fails
+ * at startup on non-matching platforms with MODULE_NOT_FOUND errors.
+ *
+ * PLATFORM SUPPORT NOTE: onnxruntime-node ≥1.24 (resolved via @huggingface/transformers)
+ * dropped darwin/x64 (Intel Mac) binaries. Available platforms are:
+ * - darwin/arm64 (Apple Silicon)
+ * - linux/x64, linux/arm64
+ * - win32/x64, win32/arm64
+ *
  * Run with: node scripts/cleanup-onnx-binaries.js
  * Or automatically via npm postinstall hook
+ *
+ * To force skip cleanup: set SKIP_ONNX_CLEANUP=1 or CI=true
  */
 
 import { existsSync, rmSync, readdirSync, statSync } from 'fs';
@@ -14,6 +26,20 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+// Skip cleanup in CI/packaging environments to preserve cross-platform compatibility
+const isCI = process.env.CI === 'true' || process.env.CI === '1';
+const skipCleanup = process.env.SKIP_ONNX_CLEANUP === '1' || process.env.SKIP_ONNX_CLEANUP === 'true';
+const isPackaging = process.env.npm_command === 'pack' || process.env.npm_lifecycle_event === 'pack';
+
+if (isCI || skipCleanup || isPackaging) {
+  console.log('\n⏭️  Skipping ONNX cleanup:');
+  if (isCI) console.log('   CI environment detected');
+  if (skipCleanup) console.log('   SKIP_ONNX_CLEANUP flag set');
+  if (isPackaging) console.log('   npm pack detected');
+  console.log('   All platform binaries will be preserved for cross-platform compatibility\n');
+  process.exit(0);
+}
 
 // Detect current platform
 const currentPlatform = process.platform; // 'darwin', 'win32', 'linux'

--- a/scripts/install-sharp-platforms.js
+++ b/scripts/install-sharp-platforms.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Pre-packaging script to install ALL sharp platform binaries
+ *
+ * Sharp's @img/* platform packages are version- and ABI-coupled to the installed sharp.
+ * A bundle assembled on one platform needs ALL platform binaries injected for cross-platform
+ * compatibility.
+ *
+ * This script:
+ * - Runs ONLY during CI/packaging (not on local installs to save bandwidth/disk)
+ * - Reads sharp's optionalDependencies from node_modules/sharp/package.json
+ * - Installs all missing platform packages with exact versions
+ *
+ * Run with: node scripts/install-sharp-platforms.js
+ * Or add to CI workflow before npm pack/publish
+ *
+ * To force run locally: set INSTALL_ALL_SHARP_PLATFORMS=1
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Only run in CI/packaging environments (skip on local installs to save bandwidth)
+const isCI = process.env.CI === 'true' || process.env.CI === '1';
+const forceInstall = process.env.INSTALL_ALL_SHARP_PLATFORMS === '1' || process.env.INSTALL_ALL_SHARP_PLATFORMS === 'true';
+const isPackaging = process.env.npm_command === 'pack' || process.env.npm_lifecycle_event === 'pack';
+
+if (!isCI && !forceInstall && !isPackaging) {
+  console.log('ℹ️  Skipping sharp platform installation (not in CI/packaging mode)');
+  console.log('   To install all platforms locally: INSTALL_ALL_SHARP_PLATFORMS=1 node scripts/install-sharp-platforms.js\n');
+  process.exit(0);
+}
+
+console.log('\n🔍 Installing all sharp platform binaries for cross-platform compatibility...');
+
+const sharpPackageJsonPath = join(__dirname, '..', 'node_modules', 'sharp', 'package.json');
+
+if (!existsSync(sharpPackageJsonPath)) {
+  console.log('⚠️  sharp package.json not found, skipping');
+  process.exit(0);
+}
+
+// Read sharp's optionalDependencies
+const sharpPackageJson = JSON.parse(readFileSync(sharpPackageJsonPath, 'utf-8'));
+const optionalDeps = sharpPackageJson.optionalDependencies || {};
+const sharpVersion = sharpPackageJson.version;
+
+console.log(`📦 sharp version: ${sharpVersion}`);
+console.log(`🌍 Found ${Object.keys(optionalDeps).length} platform packages\n`);
+
+// Check which platforms are missing
+const missingPlatforms = [];
+for (const [pkgName, version] of Object.entries(optionalDeps)) {
+  const pkgPath = join(__dirname, '..', 'node_modules', pkgName);
+  if (!existsSync(pkgPath)) {
+    missingPlatforms.push(`${pkgName}@${version}`);
+  }
+}
+
+if (missingPlatforms.length === 0) {
+  console.log('✅ All sharp platform binaries already installed\n');
+  process.exit(0);
+}
+
+console.log(`📥 Installing ${missingPlatforms.length} missing platform(s):\n`);
+missingPlatforms.forEach(pkg => console.log(`   - ${pkg}`));
+
+// Install missing platforms
+try {
+  console.log('\n🔧 Running npm install...');
+
+  // Use --no-save to avoid modifying package-lock.json
+  // Use --force to bypass platform checks (npm refuses to install platform-specific packages otherwise)
+  const installCmd = `npm install --no-save --no-audit --force ${missingPlatforms.join(' ')}`;
+
+  execSync(installCmd, {
+    stdio: 'inherit',
+    cwd: join(__dirname, '..')
+  });
+
+  console.log('\n✅ All sharp platform binaries installed successfully!');
+  console.log('   Bundle will now work on all supported platforms\n');
+
+} catch (error) {
+  console.error('\n❌ Failed to install sharp platform binaries:', error.message);
+  console.error('   Bundle may not work on all platforms');
+  process.exit(1);
+}


### PR DESCRIPTION
- Add platform support documentation to README (Intel Mac not supported in v0.4.0+)
- Add cleanup-locutus.js script to prevent case-collision issues on macOS/Windows
- Update cleanup-onnx-binaries.js to preserve all platform binaries during CI/packaging
- Add install-sharp-platforms.js to ensure all sharp binaries are included in packages
- Update postinstall hook to run all cleanup and platform installation scripts